### PR TITLE
Change rgl.triangles to triangles3d

### DIFF
--- a/R/plot3dtriangles.R
+++ b/R/plot3dtriangles.R
@@ -1,7 +1,7 @@
 plot3dtriangles <- function(m,...){
 	tm <- try(t(geometry::surf.tri(m, geometry::delaunayn(m, options="Pp"))))
 	if(!inherits(tm, "try-error"))
-		rgl::rgl.triangles(m[tm,1], m[tm,2], m[tm,3],...)
+		rgl::triangles3d(m[tm,1], m[tm,2], m[tm,3],...)
 	else
 		warning("Problem in surf.tri, tree skipped")
 }


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to
Maeswrap.  I will be deprecating a number of rgl.* function
calls. You can read about the issues here:

            https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to Maeswra in the attached
patch. These changes should work with both old and new rgl versions.
